### PR TITLE
CDC-5021-CDC-5020-xmlns-issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+snowagent.config text    eol=crlf

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).  
 This project only uses dates (yyyy-mm-dd) to track changes.
 
+## 2024-01-03
+
+### Changed
+
+- `./windows/snowagent.config` - updated xml namespace to prevent Inventory Server Errors
+- `./macos/snowagent.config` - reverted xml namespace to prevent Inventory Server Errors
+- `./linux/snowagent.config` - reverted xml namespace to prevent Inventory Server Errors
+- `./unix/snowagent.config` - reverted xml namespace to prevent Inventory Server Errors
+- `./windows/snowagent.config` - changed encoding from UTF-8-BOM to UTF-8
+
 ## 2023-11-30 - Initial Release
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@ This project only uses dates (yyyy-mm-dd) to track changes.
 
 ### Changed
 
-added `.gitattributes` file to handle line endings of configuration files properly
+added `.gitattributes` file to handle line endings of config files the same over all platforms
 
 - `./windows/snowagent.config` - updated xml namespace to prevent Inventory Server Errors
 - `./macos/snowagent.config` - reverted xml namespace to prevent Inventory Server Errors

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ This project only uses dates (yyyy-mm-dd) to track changes.
 
 ### Changed
 
+added `.gitattributes` file to handle line endings of configuration files properly
+
 - `./windows/snowagent.config` - updated xml namespace to prevent Inventory Server Errors
 - `./macos/snowagent.config` - reverted xml namespace to prevent Inventory Server Errors
 - `./linux/snowagent.config` - reverted xml namespace to prevent Inventory Server Errors

--- a/linux/snowagent.config
+++ b/linux/snowagent.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration xmlns="snowclient_settings.xsd">
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="snowclient_settings.xsd">
 <!-- Find guides how to use this template and the latest templates on https://github.com/SnowSoftwareGlobal/agent-configuration-templates-public -->
     <Agent>
         <SiteName></SiteName>

--- a/macos/snowagent.config
+++ b/macos/snowagent.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration xmlns="snowclient_settings.xsd">
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="snowclient_settings.xsd">
 <!-- Find guides how to use this template and the latest templates on https://github.com/SnowSoftwareGlobal/agent-configuration-templates-public -->
     <Agent>
         <SiteName></SiteName>

--- a/unix/snowagent.config
+++ b/unix/snowagent.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration xmlns="snowclient_settings.xsd">
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="snowclient_settings.xsd">
 <!-- Find guides how to use this template and the latest templates on https://github.com/SnowSoftwareGlobal/agent-configuration-templates-public -->
     <Agent>
         <SiteName></SiteName>

--- a/windows/snowagent.config
+++ b/windows/snowagent.config
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Configuration xmlns="snowclient_settings.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="snowclient_settings.xsd">
 <!-- Find guides how to use this template and the latest templates on https://github.com/SnowSoftwareGlobal/agent-configuration-templates-public -->
     <Agent>
         <SiteName></SiteName>


### PR DESCRIPTION

- Removed xmlns declaration, and switched back to the xmlns:xsi and xs:noNamespaceSchemaLocation used in the Linux, macOS and Unix configurations before. (closes #2 )
- Added `.gitattributes` file to set CRLF on all platforms
- changed encoding on the `./windows/snowagent.config` file from UTF-8-BOM to UTF-8